### PR TITLE
Fix Dockerfile to not install google-chrome.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,12 @@ FROM node:8-slim
 # See https://crbug.com/795759
 RUN apt-get update && apt-get install -yq libgconf-2-4
 
-# Install latest chrome dev package
-# (this is needed for included libs that are necessary dependencies for the version of Chromium bundled with Puppeteer)
-RUN apt-get update && apt-get install -y wget --no-install-recommends \
-    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && apt-get update \
-    && apt-get install -y google-chrome-unstable \
-       libxss1 \
-       libxtst6 \
+# Install dependencies of chromium bundled with puppeteer
+RUN apt-get update \
+    && apt-get install -y wget libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libdrm2 \
+      libexpat1 libgbm1 libgcc1 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 \
+       libx11-6 libx11-xcb1 libxcb-dri3-0 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 \
+       libxrender1 libxss1 libxtst6 bash xdg-utils \
       --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get purge --auto-remove -y curl \

--- a/README.md
+++ b/README.md
@@ -2,9 +2,17 @@ Node-based service providing a lightweight API for generating JPEG/PNG and PDF r
 
 # Installation and Use
 
-Installation with Docker is recommended. Simply clone this repository, `docker build`, and `docker run`. To install additional fonts in the built image, place them in a top-level `fonts` directory in this repo before building.
+## Docker
+
+Clone this repository, `docker build . -t dreamcatcher`, and `docker run dreamcatcher`.
+
+To install additional fonts in the built image, place them in a top-level `fonts` directory in this repo before building.
+
+## Standalone
 
 To run without Docker, simply `npm install && npm start`. Requires Node `8.12.0` (LTS) or newer.
+
+## Environment Variables
 
 The following optional environment variables are available for configuration:
 


### PR DESCRIPTION
There is no need to install google chrome just to get its dependencies,
the dependencies of debian's chromium-browser are now installed so that
puppeteer's embedded chromium will work.