### PR TITLE
Configurable behavior for private IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The following optional environment variables are available for configuration:
 - **BROWSER_REGEN_INTERVAL:** (Default: `100`) To maximize performance, requests share a common browser instance (running in effect as separate tabs). However, to avoid the impact of memory leaks in Chromium, the shared browser is refreshed after the number of requests specified here. Try lowering this if you notice cyclical performance degradation.
 - **PORT:** (Default: `8080`) The port on which the Dreamcatcher server will run. Only relevant for non-Docker installs; with Docker, simply map 8080 to the desired outward-facing port.
 - **SENTRY_DSN:** (Default: `undefined`) Dreamcatcher can integrate with Sentry for error reporting. To use Sentry, provide the DSN identifying your Sentry project and host.
+- **ALLOW_PRIVATE_NETWORKS:** (Default: `undefined`) Dreamcatcher blocks any requests (e.g. images, CSS) to private networks / IPs by default. Pass this env var with value `true` in order to allow such requests. (This only applies to IPv4 IP addresses; hostnames that resolve to local addresses will still pass through)
 
 **Troubleshooting Tips**
 - When testing Dreamcatcher locally using Docker and a locally-served target site, be sure to use your machine's external-facing IP address in the `url` parameter (rather than `localhost`).

--- a/helpers.js
+++ b/helpers.js
@@ -134,10 +134,14 @@ const handleError = (error, res) => {
   res.send(error.message);
 };
 
+const isPrivateNetwork = input =>
+  input.match(/(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)|(^169\.254\.)/);
+
 module.exports = {
   prepareOptions,
   prepareContent,
   capturePdf,
   captureImage,
-  handleError
+  handleError,
+  isPrivateNetwork,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,11 @@
         "once": "^1.3.1"
       }
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
     "puppeteer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.2.1.tgz",
@@ -812,6 +817,11 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "range-parser": {
       "version": "1.2.1",
@@ -988,6 +998,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "morgan": "^1.10.0",
     "on-finished": "^2.3.0",
     "puppeteer": "^5.2.1",
+    "url": "^0.11.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
 * Make dreamcatcher abort and log any requests to private IPs by default
 * Provide a flag to enable that
 * Also adds the url npm package