### PR TITLE
debug configuration for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ fonts/
 !/fonts/.keep
 profileParams.txt
 profile.sh
+.vscode/launch.json

--- a/.vscode/launch.sample.json
+++ b/.vscode/launch.sample.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch via NPM",
+      "request": "launch",
+      "runtimeArgs": [
+        "run-script",
+        "debug"
+      ],
+      "runtimeExecutable": "npm",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "node",
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.5",
   "private": true,
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "debug": "node --nolazy server.js"
   },
   "dependencies": {
     "@sentry/node": "^4.1.1",


### PR DESCRIPTION
Create a default configuration for easier debugging in VS code.

To test:

 * make sure you don't have dreamcatcher running elsewhere in port 8080
 * copy the contents of the supplied sample launch.json to your own
 * press F5 to start dreamcatcher within vscode
 * mark a debug break point e.g. in the status request handler
 * issue a status request with `curl http://localhost:8080/status`

