### PR TITLE
Reinstate puppeteer browser launch options

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,6 +71,13 @@ const app = express();
     concurrency: Cluster.CONCURRENCY_CONTEXT,
     maxConcurrency: process.env.CONCURRENCY || 15,
     monitor: process.env.MONITOR ? true : false,
+    puppeteerOptions: {
+      args: [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage"
+      ],
+    },
   });
 
   if (useSentry) app.use(Sentry.Handlers.requestHandler());


### PR DESCRIPTION
During the change to puppeteer-cluster, these options were mistakenly removed.

Reinstating these options will allow dreamcatcher to run within a docker
environment again.