### PR TITLE
Fix hanging requests for certain cases

### DIFF
--- a/server.js
+++ b/server.js
@@ -75,7 +75,8 @@ const app = express();
       args: [
         "--no-sandbox",
         "--disable-setuid-sandbox",
-        "--disable-dev-shm-usage"
+        "--disable-dev-shm-usage",
+        "--disable-web-security",
       ],
     },
   });


### PR DESCRIPTION
Webfonts in css that wouldn't load because of CORS issues could cause
*random* hangs and timeouts.

Disabling web security fixes the issue.