### PR TITLE
Fix issue where some screenshots failed due to browser disconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
  * Fix parsing of env var CONCURRENCY.
  * Disable CORS by default. Fixes an issue with some requests randomly timing out
    while a webfont could not be loaded due to CORS.
+ * Certain pages can randomly crash the browser instance. For these cases we,
+   retry a screenshot task up to a total of 3 times, before responding with an
+   error message.
 
 ## [2.0.0]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dreamcatcher",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -504,6 +504,14 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
         "lodash": "^4.17.10"
+      }
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
       }
     },
     "asynckit": {
@@ -2587,6 +2595,11 @@
       "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
       "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@sentry/node": "^4.1.1",
     "async": "^2.6.1",
+    "async-retry": "^1.3.3",
     "body-parser": "^1.19.0",
     "cookie-parser": "~1.4.3",
     "debug": "^4.2.0",


### PR DESCRIPTION
Some pages or provided HTML can cause the browser to crash / disconnect.
Those pages in my experience usually have a CORS error e.g. in their
font-face assets, or some sort of security warning. The exact cause is
unsure yet, but it's pretty random: in a specific html document, it
seems to fail anywhere between 1 in 30 or 1 in 90 times.

However with puppeteer-cluster we were not using its queuing system.
We need to wait synchronously and response to the express request, and
use puppeteer.execute(). With puppeteer-cluster's queue(), the request
could have been retried. This commit will add a retry (max. retries set
to 3, currently) to the execution of the puppeteer-cluster task itself.
Currently this seems to work and this page will get rendered.