### PR TITLE
Fix Sentry crash by dropping @sentry/tracing and aligning to 7.120.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "dreamcatcher",
       "version": "2.4.0",
       "dependencies": {
-        "@sentry/node": "^7.52.1",
-        "@sentry/tracing": "^7.52.1",
+        "@sentry/node": "^7.120.4",
         "async": "^3.2.4",
         "async-retry": "^1.3.3",
         "body-parser": "^1.19.0",
@@ -511,33 +510,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
-      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
-      "dependencies": {
-        "@sentry/core": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/core": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
-      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
-      "dependencies": {
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sentry/integrations": {
       "version": "7.120.4",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
@@ -646,37 +618,6 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/types": "7.120.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.52.1.tgz",
-      "integrity": "sha512-1afFeb0X6YcMK8mcsGXpO9rNFEF4Kd3mAUF22hXyFNWVoPNQsvdh/WxG2t3U+hLhehQ1ps3iJ0jxFRGF5zSboA==",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.52.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
-      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
-      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
-      "dependencies": {
-        "@sentry/types": "7.52.1",
-        "tslib": "^1.9.3"
       },
       "engines": {
         "node": ">=8"
@@ -5005,11 +4946,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -5779,27 +5715,6 @@
         }
       }
     },
-    "@sentry-internal/tracing": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
-      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
-      "requires": {
-        "@sentry/core": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/core": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
-      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
-      "requires": {
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
-      }
-    },
     "@sentry/integrations": {
       "version": "7.120.4",
       "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.4.tgz",
@@ -5879,28 +5794,6 @@
             "@sentry/types": "7.120.4"
           }
         }
-      }
-    },
-    "@sentry/tracing": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.52.1.tgz",
-      "integrity": "sha512-1afFeb0X6YcMK8mcsGXpO9rNFEF4Kd3mAUF22hXyFNWVoPNQsvdh/WxG2t3U+hLhehQ1ps3iJ0jxFRGF5zSboA==",
-      "requires": {
-        "@sentry-internal/tracing": "7.52.1"
-      }
-    },
-    "@sentry/types": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
-      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row=="
-    },
-    "@sentry/utils": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
-      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
-      "requires": {
-        "@sentry/types": "7.52.1",
-        "tslib": "^1.9.3"
       }
     },
     "@tootallnate/quickjs-emscripten": {
@@ -8910,11 +8803,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "test-with-coverage": "./node_modules/.bin/nyc --reporter=text --reporter=html mocha"
   },
   "dependencies": {
-    "@sentry/node": "^7.52.1",
-    "@sentry/tracing": "^7.52.1",
+    "@sentry/node": "^7.120.4",
     "async": "^3.2.4",
     "async-retry": "^1.3.3",
     "body-parser": "^1.19.0",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const cookieParser = require("cookie-parser");
 const bodyParser = require("body-parser");
 const retry = require('async-retry');
 const Sentry = require("@sentry/node");
-const Tracing = require("@sentry/tracing");
 const { Cluster } = require('puppeteer-cluster');
 const {
   log,
@@ -93,7 +92,7 @@ const app = express();
 const useSentry = !!process.env.SENTRY_DSN;
 if (useSentry) {
   const useSentryExpress = !!process.env.SENTRY_EXPRESS;
-  const sentryIntegrations = useSentryExpress ? [new Tracing.Integrations.Express({app})] : [];
+  const sentryIntegrations = useSentryExpress ? [new Sentry.Integrations.Express({app})] : [];
   const tracesSampleRate = process.env.SENTRY_TRACES_SAMPLE_RATE ? parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE) : 0;
   Sentry.init({
     dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
**Fix Sentry crash by dropping @sentry/tracing and aligning to 7.120.4**

@sentry/node had drifted to 7.120.4 while @sentry/tracing stayed at
7.52.1, so the transaction created by the old package lacked the
setAttribute method the new handlers call, crashing the process on
every sampled request. The Express integration now comes from
@sentry/node itself, which ships it since v7.47.